### PR TITLE
Fix incorrect file paths

### DIFF
--- a/build.php
+++ b/build.php
@@ -49,8 +49,8 @@ $files = array_filter( array_merge(
 	[
 		__DIR__ . '/.phpcs.xml',
 		__DIR__ . '/webpack.mix.js',
-		__DIR__ . 'package.json',
-		__DIR__ . 'composer.json'
+		__DIR__ . '/package.json',
+		__DIR__ . '/composer.json'
 	],
 	glob( __DIR__ . '/*.php', GLOB_NOSORT ),
 	rglob( __DIR__ . '/src/*.php', GLOB_NOSORT )

--- a/give-addon-boilerplate.php
+++ b/give-addon-boilerplate.php
@@ -29,7 +29,7 @@ define( 'ADDON_CONSTANT_DIR', plugin_dir_path( ADDON_CONSTANT_FILE ) );
 define( 'ADDON_CONSTANT_URL', plugin_dir_url( ADDON_CONSTANT_FILE ) );
 define( 'ADDON_CONSTANT_BASENAME', plugin_basename( ADDON_CONSTANT_FILE ) );
 
-require './vendor/autoload.php';
+require 'vendor/autoload.php';
 
 // Activate add-on hook.
 register_activation_hook( ADDON_CONSTANT_FILE, [ Activation::class, 'activateAddon' ] );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #27 

## Description
Trying to install this add-on boilerplate on a Linux machine throws several errors caused by "incorrect" file paths. 
This PR fixes that issue by providing the correct file paths. 

## Affects

build.php
give-addon-boilerplate.php


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Clone add-on boilerplate repository
2. Follow the instructions on how to build the add-on provided in the description
