### PR TITLE
Load required Give_Addon_Activation_Banner class if not loaded

### DIFF
--- a/src/Addon/ActivationBanner.php
+++ b/src/Addon/ActivationBanner.php
@@ -17,6 +17,11 @@ class ActivationBanner {
 	 * @return void
 	 */
 	public function show() {
+		// Check for Activation banner class.
+		if ( ! class_exists( 'Give_Addon_Activation_Banner' ) ) {
+			include GIVE_PLUGIN_DIR . 'includes/admin/class-addon-activation-banner.php';
+		}
+
 		// Only runs on admin.
 		$args = [
 			'file'              => ADDON_CONSTANT_FILE,

--- a/src/Domain/AddonServiceProvider.php
+++ b/src/Domain/AddonServiceProvider.php
@@ -49,7 +49,7 @@ class AddonServiceProvider implements ServiceProvider {
 		SettingsPage::registerPage( AddonSettingsPage::class );
 
 		Hooks::addAction( 'admin_init', License::class, 'check' );
-		Hooks::addAction( 'admin_init', ActivationBanner::class, 'show' );
+		Hooks::addAction( 'admin_init', ActivationBanner::class, 'show', 20 );
 		// Load backend assets.
 		Hooks::addAction( 'admin_enqueue_scripts', Assets::class, 'loadBackendAssets' );
 		/**


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #26

## Description
This PR resolves the issue where ActivationBanner class throws a fatal error because it tries to utilize Give_Addon_Activation_Banner class which is not loaded. The issue is resolved by adding a check if Give_Addon_Activation_Banner is loaded, and if not, it will load the required class. 

## Affects

ActivationBanner class

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
