### PR TITLE
Extract template parameters so they can be used within template

### DIFF
--- a/src/Addon/View.php
+++ b/src/Addon/View.php
@@ -30,6 +30,7 @@ class View {
 		}
 
 		ob_start();
+		extract( $templateParams );
 		include $template;
 		$content = ob_get_clean();
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #34

## Description

This PR is resolving the issue where template parameters are not passed down to the template. This functionality already existed but was accidentally removed.

## Affects

`View` helper class

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Create a template file named `test.php` in `src/Domain/resources/views/` directory
2. Add `<?php var_dump( $testArg );` to the test.php file and save
3. Try to load the template in `AddonServiceProvider::loadBackend` by using `View::render('test', ['testArg'=>'test value']);`
