### PR TITLE
Multiple domains can now make use of View hleper class

### DIFF
--- a/build.php
+++ b/build.php
@@ -62,6 +62,7 @@ $replacements = [
 	'GiveAddon'         => trim( $namespace ),
 	'\\Domain'          => trim( "\\$domain" ),
 	'src/Domain'        => trim( "src/$domain" ),
+	'ADDON_DOMAIN'      => trim( $domain ),
 	'ADDON_NAME'        => trim( $name ),
 	'ADDON_CONSTANT'    => trim( $constant ),
 	'ADDON_DESCRIPTION' => trim( $description ),

--- a/src/Addon/View.php
+++ b/src/Addon/View.php
@@ -34,7 +34,7 @@ class View {
 	public static function load( $view, $templateParams = [], $echo = false ) {
 		// Get domain and file path
 		list ( $domain, $file ) = static::getPaths( $view );
-		$template = GIVE_TEST_DATA_DIR . "src/{$domain}/resources/views/{$file}.php";
+		$template = ADDON_CONSTANT_DIR . "src/{$domain}/resources/views/{$file}.php";
 
 		if ( ! file_exists( $template ) ) {
 			throw new InvalidArgumentException( "View template file {$template} not exist" );

--- a/src/Addon/View.php
+++ b/src/Addon/View.php
@@ -11,19 +11,30 @@ use InvalidArgumentException;
  * @copyright   Copyright (c) 2020, GiveWP
  */
 class View {
+	/**
+	 * Default add-on domain
+	 */
+	const DEFAULT_DOMAIN = 'ADDON_DOMAIN';
 
 	/**
-	 * @param string $view
+	 * @param string $view Template name
+	 * When using multiple domains within this add-on, the domain directory can be set by using "." in the template name.
+	 * String before the "." character is domain directory, and everything after is the template file path
+	 * Example usage: View::render( 'DomainName.templateName' );
+	 * This will try to load src/DomainName/resources/view/templateName.php file
+	 *
 	 * @param array $templateParams Arguments for template.
 	 * @param bool $echo
 	 *
+	 * @return string|void
 	 * @throws InvalidArgumentException if template file not exist
 	 *
 	 * @since 1.0.0
-	 * @return string|void
 	 */
 	public static function load( $view, $templateParams = [], $echo = false ) {
-		$template = ADDON_CONSTANT_DIR . 'src/Addon/resources/views/' . $view . '.php';
+		// Get domain and file path
+		list ( $domain, $file ) = static::getPaths( $view );
+		$template = GIVE_TEST_DATA_DIR . "src/{$domain}/resources/views/{$file}.php";
 
 		if ( ! file_exists( $template ) ) {
 			throw new InvalidArgumentException( "View template file {$template} not exist" );
@@ -48,5 +59,25 @@ class View {
 	 */
 	public static function render( $view, $vars = [] ) {
 		static::load( $view, $vars, true );
+	}
+
+	/**
+	 * Get domain and template file path
+	 *
+	 * @param string $path
+	 *
+	 * @return array
+	 * @since 1.0.0
+	 */
+	private static function getPaths( $path ) {
+		// Check for . delimiter
+		if ( false === strpos( $path, '.' ) ) {
+			return [
+				self::DEFAULT_DOMAIN,
+				$path
+			];
+		}
+
+		return explode( '.', $path, 2 );
 	}
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #35

## Description

When building an add-on with multiple domains, any domain that is not the "default" domain, cannot make use of the `View` helper class. This PR resolves this issue by enabling developers to set domain paths within the View class template name argument.

The domain directory path can be set by using `.` in the template name.
Example: `View::render( 'DomainName.templateName' );`
String before the `.` character is domain directory, and everything after is the template file path.
This will try to load src/`DomainName`/resources/view/`templateName`.php file

## Affects
View helper class


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Generate a new add-on
2. Add a new domain directory named `TestDomain` in `src/` directory
3. Create a new template file named `testdomain.php` in `TestDomain/resources/views/` directory
4. Try to load `testdomain.php` template using `View::render('TestDomain.testdomain')`

