### PR TITLE
PHPCS now excludes the entire `resource/` directory

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -11,9 +11,8 @@
 	<exclude-pattern>node_modules/*</exclude-pattern>
 	<exclude-pattern>vendor/*</exclude-pattern>
 	<exclude-pattern>languages/*</exclude-pattern>
-	<exclude-pattern>resources/css/*</exclude-pattern>
-	<exclude-pattern>resources/js/*</exclude-pattern>
-	<exclude-pattern>resources/images/*</exclude-pattern>
+	<exclude-pattern>resources/*</exclude-pattern>
+	<exclude-pattern>/tests/*</exclude-pattern>
 
 	<!-- Bring in WP rules. -->
 	<rule ref="WordPress-Core">


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #40

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Replaces the specific `css`, `js`, and `images` exclude pattern by excluding the entire `resources/` directory.

This changes comes form https://github.com/impress-org/give-peer-to-peer/commit/59b9a217fe3756fc3c38a6f56f02ce83e8ba8282.
