### PR TITLE
PHPCS WP rules are now structured for an autoloaded `src/` directory

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -29,7 +29,7 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="give-p2p"/>
+			<property name="text_domain" type="array" value="ADDON_TEXTDOMAIN"/>
 		</properties>
 	</rule>
 </ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -17,30 +17,19 @@
 
 	<!-- Bring in WP rules. -->
 	<rule ref="WordPress-Core">
-		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax.Found" />
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
-	</rule>
-
-	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
-		<exclude-pattern>src/*</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
-		<exclude-pattern>src/*</exclude-pattern>
-	</rule>
-
-	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
-		<exclude-pattern>src/*</exclude-pattern>
-	</rule>
-
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
-	  <type>warning</type>
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.InterpolatedVariableNotSnakeCase" />
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="ADDON_TEXTDOMAIN"/>
+			<property name="text_domain" type="array" value="give-p2p"/>
 		</properties>
 	</rule>
 </ruleset>


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #42

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This changes comes from a refactor in https://github.com/impress-org/give-peer-to-peer/commit/6c7bc7b59352f26b97114ef86be83dbf68e566d4

