### PR TITLE
PHPlinting is now managed by composer instead of npm

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,6 @@
 {
     "*.json": ["prettier --write"],
-    "*.php": ["npm run lint:textdomain", "npm run lint:php:fix", "npm run lint:php"],
+    "*.php": ["npm run lint:textdomain", "composer run lint:php:fix", "composer run lint:php"],
     "*.{js,jsx}": ["eslint --fix"],
     "*.scss": ["stylelint --fix"]
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
     },
     "scripts": {
+        "lint:php": "./vendor/bin/phpcs -v -s --colors",
+        "lint:php:fix": "./vendor/bin/phpcbf -v --colors",
         "post-install-cmd": [
             "@install-codestandards"
         ],

--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "lint": "npm run lint:js & npm run lint:scss & npm run lint:php",
         "lint:js": "eslint src/**/resources/**/*.js",
-        "lint:js-fix": "eslint src/**/resources/**/*.js --fix",
-        "lint:php": "./vendor/bin/phpcs -v -s --colors",
-        "lint:php:fix": "./vendor/bin/phpcbf -v --colors",
+        "lint:js:fix": "eslint src/**/resources/**/*.js --fix",
         "lint:textdomain": "node ./wp-textdomain.js",
         "lint:scss": "stylelint src/**/resources/**/*.scss"
     },


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #44

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

- Removes `npm` scripts for linting PHP
- Adds `composer` scripts for linting PHP
- Updates huskey to use composer scripts to lint PHP

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

Note: This also changes the syntax of the `lint:js-fix` command to be `lint:js:fix`, which matches the `lint:php:fix` format.
