### PR TITLE
Fix: Update addon name in reame.txt

### DIFF
--- a/build.php
+++ b/build.php
@@ -47,6 +47,7 @@ $domain = ucfirst( trim( readline(
 // Retrieve the files
 $files = array_filter( array_merge(
 	[
+		__DIR__ . '/readme.txt',
 		__DIR__ . '/.phpcs.xml',
 		__DIR__ . '/webpack.mix.js',
 		__DIR__ . '/composer.json'

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Requires at least: 4.9
 Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 1.0
-Requires Give: 2.8.0
+Requires Give: 2.15.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
-=== Give - Addon Boilerplate ===
-Contributors: givewp, wordimpress, dlocc, webdevmattcrom
+=== Give - ADDON_NAME ===
+Contributors: givewp, dlocc, webdevmattcrom
 Donate link: https://givewp.com/
 Tags: givewp, donation, donations, donation plugin, wordpress donation plugin, wp donation, donors, display donors, give donors, anonymous donations
 Requires at least: 4.8

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: givewp, dlocc, webdevmattcrom
 Donate link: https://givewp.com/
 Tags: givewp, donation, donations, donation plugin, wordpress donation plugin, wp donation, donors, display donors, give donors, anonymous donations
-Requires at least: 4.8
-Tested up to: 5.5
+Requires at least: 4.9
+Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 1.0
 Requires Give: 2.8.0


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR includes the file `readme.txt` in the list of files parsed for replacements and adds the `ADDON_NAME` replacement tag to the header text.

Also, this removes `wordimpress` from the default contributors list.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Building a new add-on should update the `readme.txt` to include the `ADDON_NAME`.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

