### PR TITLE
feature: Add pre-release workflow.

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,12 @@
+name: Build Plugin Pre-Release
+
+on:
+    release:
+        types: [ prereleased ]
+
+jobs:
+    build:
+        uses: impress-org/givewp-github-actions/.github/workflows/pre-release.yml@master
+        with:
+            plugin_slug: ADDON_ID
+            zip_name: ADDON_ID

--- a/build.php
+++ b/build.php
@@ -48,9 +48,9 @@ $domain = ucfirst( trim( readline(
 $files = array_filter( array_merge(
 	[
 		__DIR__ . '/readme.txt',
-		__DIR__ . '/.phpcs.xml',
 		__DIR__ . '/webpack.mix.js',
-		__DIR__ . '/composer.json'
+		__DIR__ . '/composer.json',
+        __DIR__ . '/.github/workflows/pre-release.yml',
 	],
 	glob( __DIR__ . '/*.php', GLOB_NOSORT ),
 	rglob( __DIR__ . '/src/*.php', GLOB_NOSORT )


### PR DESCRIPTION
## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This PR adds the new declarative, re-usable pre-release workflow.

It also removes the `phpcs` file from the build list, since the file does not exist and throws an error.

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->

Running `build.php` should replace `ADDON_ID` in the `yaml` file.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

