### PR TITLE
fix: Correct namespace to match file path

### DIFF
--- a/src/Addon/View.php
+++ b/src/Addon/View.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace GiveAddon\Addon\Helpers;
+namespace GiveAddon\Addon;
 
 use InvalidArgumentException;
 


### PR DESCRIPTION
## Description

This PR corrects the namespace of the `Addon/View` class to match the autoloaded file path.
